### PR TITLE
Correção de bug ao abrir formulários

### DIFF
--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -385,12 +385,24 @@ public class WebviewActivity extends AppCompatActivity {
 
             return url;
         }
+        public String formShortLinkFixer(WebView webView, String url){
+            Pattern pattern = Pattern.compile("forms.gle/[\\w]{10}\\w*.*browser_fallback_url=(.*/viewform)",Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(url);
+            String fixed_url;
+            if(matcher.find()) {
+                fixed_url = matcher.group(1);
+                webView.loadUrl(fixed_url);
+            }else{
+                fixed_url = url;
+            }
+            return fixed_url;
+        };
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView webView, String urlParameter) {
             Log.d("URL: ", urlParameter);
             String url = this.youtubeProtect(webView, urlParameter);
-
+            url = this.formShortLinkFixer(webView, url);
             try {
                 Log.d("URL: ", url);
                 if (url.startsWith("javascript"))


### PR DESCRIPTION
Links encurtados para formulários são redirecionados para uma página que não funciona, é apresentada a seguinte tela:
![page_not_available](https://user-images.githubusercontent.com/45996980/112349421-77119480-8ca7-11eb-8668-1aad07d57b98.png)
Alguns outros links até abrem porém em um app externo, instalado no dispositivo, e não deveria ser o comportamento do app.

A solução encontrada para o problema apresentado foi realizar uma interceptação entre todos os links que são clicáveis dentro do aplicativo. Para tal, utilizamos uma regex para links encurtados e consultamos a URL do rollback que estava dentro do header 'location' no elemento S.browser_fallback_url.

Realizando essa alteração foi possível abrir o formulário com link encurtado normalmente:
![Captura de Tela 2021-03-24 às 14 01 54](https://user-images.githubusercontent.com/45996980/112352473-8bef2780-8ca9-11eb-94e8-2f333448976c.png)

FIX #50 

Sendo assim, foram mapeadas as seguintes formas de inserir formulários:
    - Link completo do formulário no formato `https://docs.google.com/forms/d/${ID_DO_FORMULARIO}`
    - Link encurtado no formato `https://forms.gle/${ID_ENCURTADO_DO_FORMULARIO}`. Corrigido nessa issue, o PR foi aberto no repositório oficial e pode ser encontrado aqui.
Obs: Links no formato `https://drive.google.com/file/d/${ID_DO_FORMULARIO}` podem ser abertos porém o estudante não conseguirá responder ao questionário, este será apenas mostrado sem interação para respondê-lo.

É necessário analisar se formulários inseridos sem link (como arquivo) no app funcionam como deveria. Porém a conta que temos acesso para testes não nos permite inserção de novos conteúdos.