### PR TITLE
Adicionar botão de controle de histórico de navegação

### DIFF
--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -62,6 +62,7 @@ public class WebviewActivity extends AppCompatActivity {
     private String mCameraPhotoPath;
     private static final int INPUT_FILE_REQUEST_CODE = 1;
     private static final int FILECHOOSER_RESULTCODE = 1;
+    FloatingActionButton fab;
 
     private File createImageFile() throws IOException {
         // Create an image file name
@@ -160,16 +161,11 @@ public class WebviewActivity extends AppCompatActivity {
 
         url = getIntent().getStringExtra("url");
         myWebView.loadUrl(url);
-        FloatingActionButton fab = findViewById(R.id.fab);
+        fab = findViewById(R.id.fab);
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if(myWebView.canGoBack()){
-                    myWebView.goBack();
-                }
-                else{
-                    WebviewActivity.this.onBackPressed();
-                }
+                myWebView.goBack();
             }
         });
     }
@@ -397,6 +393,20 @@ public class WebviewActivity extends AppCompatActivity {
             }
 
             return url;
+        }
+
+        public void setBackFloatButtonVisibilty(WebView view){
+            if(view.canGoBack()){
+                fab.setVisibility(View.VISIBLE);
+            }else{
+                fab.setVisibility(View.GONE);
+            }
+        }
+
+        @Override
+        public void onLoadResource(WebView view, String url) {
+            setBackFloatButtonVisibilty(view);
+            super.onLoadResource(view, url);
         }
 
         @Override

--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -164,7 +164,12 @@ public class WebviewActivity extends AppCompatActivity {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                myWebView.goBack();
+                if(myWebView.canGoBack()){
+                    myWebView.goBack();
+                }
+                else{
+                    WebviewActivity.this.onBackPressed();
+                }
             }
         });
     }

--- a/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WebviewActivity.java
@@ -36,6 +36,7 @@ import androidx.core.content.ContextCompat;
 
 import com.datami.smi.SdState;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.io.File;
 import java.io.IOException;
@@ -159,6 +160,13 @@ public class WebviewActivity extends AppCompatActivity {
 
         url = getIntent().getStringExtra("url");
         myWebView.loadUrl(url);
+        FloatingActionButton fab = findViewById(R.id.fab);
+        fab.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                myWebView.goBack();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -6,11 +6,28 @@
     android:layout_height="match_parent"
     tools:context=".WebviewActivity">
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@+id/web_view"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:background="#FFFFFF"
+        android:clickable="true"
+        android:focusable="true"
+        android:tint="#FFFFFF"
+        app:srcCompat="?attr/homeAsUpIndicator"
+        android:contentDescription="@string/todo" />
+
     <WebView
         android:id="@+id/web_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/navigation" />
+        android:layout_above="@+id/navigation" >
+
+    </WebView>
 
     <ProgressBar
         android:id="@+id/progressBar1"
@@ -33,5 +50,7 @@
         app:itemIconTint="@drawable/selector"
         app:itemTextColor="@drawable/selector"
         app:labelVisibilityMode="labeled"
-        app:menu="@menu/main_menu" />
+        app:menu="@menu/main_menu" >
+
+    </com.google.android.material.bottomnavigation.BottomNavigationView>
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -18,8 +18,7 @@
         android:clickable="true"
         android:focusable="true"
         android:tint="#FFFFFF"
-        app:srcCompat="?attr/homeAsUpIndicator"
-        android:contentDescription="@string/todo" />
+        app:srcCompat="?attr/homeAsUpIndicator" />
 
     <WebView
         android:id="@+id/web_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="https_escolaemcasa_se_df_gov_br"><u>Escola em Casa DF (site)</u></string>
     <string name="https_escolaemcasa_se_df_gov_br_index_php_como_acessar"><u>Como acessar o Google Sala de Aula</u></string>
     <string name="http_www_se_df_gov_br"><u>Secretaria da Educação (site)</u></string>
+    <string name="todo">TODO</string>
 </resources>


### PR DESCRIPTION
**Descrição da mudança**  
<!-- Descreva de forma clara e concisa sobre a mudança feita. -->
Foi adicionado um botão flutuante para retornar a página anterior caso isso seja possível. O botão se esconde automaticamente caso não seja possível retornar a página anterior.
**Feature**  
<!-- Marque o checkbox correspondente a mudança. -->
- [x] Correção de bug.
- [x] Adição de nova fucionalidade.
- [ ] Documentação.
- [ ] Outro: <!-- Especifique. -->

**Issue relacionada**  
<!-- Adicionar FIX com as issues relacionadas ao abrir o PR. Ex.: Fix #15 -->
FIX [#13](https://github.com/GCES-Escola-em-Casa-2020-2/wiki/issues/13)

**Screenshots**  
<!-- Se aplicável, adicione imagens da tela para ajudar a explicar a mudança feita. -->
![Captura de Tela 2021-03-23 às 15 29 03](https://user-images.githubusercontent.com/45996980/112199040-8384e700-8bec-11eb-9c50-3fd84b979073.png)

https://user-images.githubusercontent.com/45996980/112199493-fd1cd500-8bec-11eb-947c-41755cf41080.mov


**Informações adicionais**  
<!-- Comente outra informação relevante sobre o seu problema aqui. -->
Ao utilizar o webview do app em alguns momentos o app não responde mais aos toques dentro do navegador e ao pressionar o botão de voltar nada acontece ou o app simplesmente fecha. Para solucionar isso é necessário clicar em outro item na barra de navegação e então retornar a página que estava sendo utilizada. Como solução foi adicionado um botão auxiliar flutuante que permite que o usuário volte até a página anterior sem muitos problemas além de não fechar o app ao realizar tal ação.