### PR TITLE
Salvar conteúdo da activity do webview ao trocar de tela

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
             android:windowSoftInputMode="adjustPan">
         </activity>
         <activity
-            android:name=".WebviewActivity"
+            android:name=".ClassroomActivity"
             android:alwaysRetainTaskState="true"
             android:configChanges="orientation|screenSize"
             android:launchMode="singleInstance"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,9 @@
         <activity
             android:name=".WebviewActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan"
+            android:launchMode="singleInstance"
+            android:alwaysRetainTaskState="true"/>
         <activity
             android:name=".AboutActivity"
             android:configChanges="orientation|screenSize"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-feature android:name="android.hardware.camera" />
 
+    <uses-feature android:name="android.hardware.camera" />
 
     <application
         android:name=".MyApplication"
@@ -22,17 +22,23 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
-
+        <activity
+            android:name=".WikipediaActivity"
+            android:alwaysRetainTaskState="true"
+            android:configChanges="orientation|screenSize"
+            android:launchMode="singleInstance"
+            android:windowSoftInputMode="adjustPan">
+        </activity>
         <activity
             android:name=".WebviewActivity"
+            android:alwaysRetainTaskState="true"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustPan"
             android:launchMode="singleInstance"
-            android:alwaysRetainTaskState="true"/>
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".AboutActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".QuestionsActivity"
             android:configChanges="orientation|screenSize"

--- a/app/src/main/java/org/cordova/quasar/corona/app/AboutActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/AboutActivity.java
@@ -22,7 +22,7 @@ public class AboutActivity extends AppCompatActivity {
                 item -> {
                     switch (item.getItemId()) {
                         case R.id.classroom:
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                                     .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
                             overridePendingTransition(0, 0);
                             navigationView.getMenu().getItem(0).setChecked(true);
@@ -54,18 +54,18 @@ public class AboutActivity extends AppCompatActivity {
 
         switch (link) {
             case "escola_em_casa_btn":
-                startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                         .putExtra("url", "https://escolaemcasa.se.df.gov.br/"));
                 overridePendingTransition(0, 0);
                 break;
             case "como_acessar_btn":
-                startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                         .putExtra("url",
                                 "https://escolaemcasa.se.df.gov.br/index.php/como-acessar/"));
                 overridePendingTransition(0, 0);
                 break;
             case "secretaria_site_btn":
-                startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                         .putExtra("url", "http://www.se.df.gov.br/"));
                 overridePendingTransition(0, 0);
                 break;

--- a/app/src/main/java/org/cordova/quasar/corona/app/AboutActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/AboutActivity.java
@@ -28,7 +28,7 @@ public class AboutActivity extends AppCompatActivity {
                             navigationView.getMenu().getItem(0).setChecked(true);
                             return true;
                         case R.id.wikipedia:
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), WikipediaActivity.class)
                                     .putExtra("url", "https://pt.wikipedia.org/"));
                             overridePendingTransition(0, 0);
                             navigationView.getMenu().getItem(1).setChecked(true);

--- a/app/src/main/java/org/cordova/quasar/corona/app/ClassroomActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/ClassroomActivity.java
@@ -50,7 +50,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class WebviewActivity extends AppCompatActivity {
+public class ClassroomActivity extends AppCompatActivity {
     private WebView myWebView;
     private String url;
     private ProgressBar spinner;
@@ -81,12 +81,12 @@ public class WebviewActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.activity_webview);
+        setContentView(R.layout.activity_classroom);
 
-        if (ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.CAMERA) +
-                ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) +
-                ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-            Toast.makeText(WebviewActivity.this, "Permissões já concedidas", Toast.LENGTH_SHORT);
+        if (ContextCompat.checkSelfPermission(ClassroomActivity.this, Manifest.permission.CAMERA) +
+                ContextCompat.checkSelfPermission(ClassroomActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) +
+                ContextCompat.checkSelfPermission(ClassroomActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+            Toast.makeText(ClassroomActivity.this, "Permissões já concedidas", Toast.LENGTH_SHORT);
         } else {
             requestCameraPermission();
         }
@@ -101,7 +101,7 @@ public class WebviewActivity extends AppCompatActivity {
                             if (url.equals("https://classroom.google.com/a/estudante.se.df.gov.br")) {
                                 return true;
                             }
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                                     .putExtra("url",
                                             "https://classroom.google.com/a/estudante.se.df.gov.br"));
                             overridePendingTransition(0, 0);
@@ -241,14 +241,14 @@ public class WebviewActivity extends AppCompatActivity {
     }
 
     private void requestCameraPermission() {
-        if (ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.CAMERA) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            new AlertDialog.Builder(WebviewActivity.this).setTitle("Permissões Negadas").setMessage("Para o funcionamento correto do Google Sala de Aula, por favor aceite as permissões necessárias.")
+        if (ActivityCompat.shouldShowRequestPermissionRationale(ClassroomActivity.this, Manifest.permission.CAMERA) ||
+                ActivityCompat.shouldShowRequestPermissionRationale(ClassroomActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
+                ActivityCompat.shouldShowRequestPermissionRationale(ClassroomActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+            new AlertDialog.Builder(ClassroomActivity.this).setTitle("Permissões Negadas").setMessage("Para o funcionamento correto do Google Sala de Aula, por favor aceite as permissões necessárias.")
                     .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
-                            ActivityCompat.requestPermissions(WebviewActivity.this, new String[]{Manifest.permission.CAMERA,
+                            ActivityCompat.requestPermissions(ClassroomActivity.this, new String[]{Manifest.permission.CAMERA,
                                     Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_CODE);
                         }
                     }).setNegativeButton("Cancelar", new DialogInterface.OnClickListener() {

--- a/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
@@ -9,7 +9,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+        startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                 .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
         overridePendingTransition(0, 0);
     }

--- a/app/src/main/java/org/cordova/quasar/corona/app/QuestionsActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/QuestionsActivity.java
@@ -27,7 +27,7 @@ public class QuestionsActivity extends AppCompatActivity {
                             navigationView.getMenu().getItem(0).setChecked(true);
                             return true;
                         case R.id.wikipedia:
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), WikipediaActivity.class)
                                     .putExtra("url", "https://pt.wikipedia.org/"));
                             overridePendingTransition(0, 0);
                             navigationView.getMenu().getItem(1).setChecked(true);

--- a/app/src/main/java/org/cordova/quasar/corona/app/QuestionsActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/QuestionsActivity.java
@@ -21,7 +21,7 @@ public class QuestionsActivity extends AppCompatActivity {
                 item -> {
                     switch (item.getItemId()) {
                         case R.id.classroom:
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                                     .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
                             overridePendingTransition(0, 0);
                             navigationView.getMenu().getItem(0).setChecked(true);

--- a/app/src/main/java/org/cordova/quasar/corona/app/WikipediaActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WikipediaActivity.java
@@ -50,7 +50,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class WebviewActivity extends AppCompatActivity {
+public class WikipediaActivity extends AppCompatActivity {
     private WebView myWebView;
     private String url;
     private ProgressBar spinner;
@@ -64,36 +64,15 @@ public class WebviewActivity extends AppCompatActivity {
     private static final int FILECHOOSER_RESULTCODE = 1;
     FloatingActionButton fab;
 
-    private File createImageFile() throws IOException {
-        // Create an image file name
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date());
-        String imageFileName = "JPEG_" + timeStamp + "_";
-        File storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-        File imageFile = File.createTempFile(
-                imageFileName,  /* prefix */
-                ".jpg",         /* suffix */
-                storageDir      /* directory */
-        );
-        return imageFile;
-    }
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        setContentView(R.layout.activity_webview);
-
-        if (ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.CAMERA) +
-                ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) +
-                ContextCompat.checkSelfPermission(WebviewActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-            Toast.makeText(WebviewActivity.this, "Permissões já concedidas", Toast.LENGTH_SHORT);
-        } else {
-            requestCameraPermission();
-        }
+        setContentView(R.layout.activity_wikipedia);
 
         BottomNavigationView navigationView = findViewById(R.id.navigation);
 
-        navigationView.setSelectedItemId(R.id.classroom);
+        navigationView.setSelectedItemId(R.id.wikipedia);
         navigationView.setOnNavigationItemSelectedListener(
                 item -> {
                     switch (item.getItemId()) {
@@ -240,29 +219,6 @@ public class WebviewActivity extends AppCompatActivity {
         }
     }
 
-    private void requestCameraPermission() {
-        if (ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.CAMERA) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
-                ActivityCompat.shouldShowRequestPermissionRationale(WebviewActivity.this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            new AlertDialog.Builder(WebviewActivity.this).setTitle("Permissões Negadas").setMessage("Para o funcionamento correto do Google Sala de Aula, por favor aceite as permissões necessárias.")
-                    .setPositiveButton("Ok", new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialogInterface, int i) {
-                            ActivityCompat.requestPermissions(WebviewActivity.this, new String[]{Manifest.permission.CAMERA,
-                                    Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_CODE);
-                        }
-                    }).setNegativeButton("Cancelar", new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialogInterface, int i) {
-                    dialogInterface.dismiss();
-                }
-            }).create().show();
-        } else {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.CAMERA,
-                    Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, PERMISSION_CODE);
-        }
-    }
-
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == PERMISSION_CODE) {
@@ -332,32 +288,32 @@ public class WebviewActivity extends AppCompatActivity {
             super.onPageFinished(view, url);
 
             view.loadUrl(
-                "javascript:(function f(e) {" +
-                    "var email = document.getElementsByName('identifier');" +
+                    "javascript:(function f(e) {" +
+                            "var email = document.getElementsByName('identifier');" +
 
-                    "email[0].oninput = function(value) {" +
-                        "if(!/^\\w?([\\.-]?\\w+)*(@)?((e(d(u)?)?)?|(e(s(t(u(d(a(n(t(e)?)?)?)?)?)?)?)?)?)?(\\.)?(s(e(\\.(d(f(\\.(g(o(v(\\.(b(r)?)?)?)?)?)?)?)?)?)?)?)?$/.test(email[0].value)){" +
+                            "email[0].oninput = function(value) {" +
+                            "if(!/^\\w?([\\.-]?\\w+)*(@)?((e(d(u)?)?)?|(e(s(t(u(d(a(n(t(e)?)?)?)?)?)?)?)?)?)?(\\.)?(s(e(\\.(d(f(\\.(g(o(v(\\.(b(r)?)?)?)?)?)?)?)?)?)?)?)?$/.test(email[0].value)){" +
                             "email[0].value = email[0].value.split('@')[0];" +
                             "alert('São permitidos apenas emails com domínio: @edu.se.df.gov.br ou @estudante.se.df.gov.br ou @se.df.gov.br');" +
                             "return false;" +
-                        "}" +
-                    "}" +
-                "})()");
+                            "}" +
+                            "}" +
+                            "})()");
 
             view.loadUrl(
-                "javascript:(function f() {" +
-                    "document.getElementsByClassName('OIPlvf')[0].style.display='none'; " +
+                    "javascript:(function f() {" +
+                            "document.getElementsByClassName('OIPlvf')[0].style.display='none'; " +
 
-                    "document.getElementsByClassName('Y4dIwd')[0].innerHTML = 'Use sua conta Google Sala De Aula (@edu.se.df.gov.br ou @estudante.se.df.gov.br ou @se.df.gov.br)'" +
-                "})()");
+                            "document.getElementsByClassName('Y4dIwd')[0].innerHTML = 'Use sua conta Google Sala De Aula (@edu.se.df.gov.br ou @estudante.se.df.gov.br ou @se.df.gov.br)'" +
+                            "})()");
             view.loadUrl(
-                "javascript:(function f() {" +
-                    "document.getElementsByClassName('docs-ml-header-item docs-ml-header-drive-link')[0].style.display='none'; " +
-                "})()");
+                    "javascript:(function f() {" +
+                            "document.getElementsByClassName('docs-ml-header-item docs-ml-header-drive-link')[0].style.display='none'; " +
+                            "})()");
             view.loadUrl(
-                "javascript:(function f() {" +
-                        "document.getElementById('p-donation').style.display='none'; " +
-                        "})()");
+                    "javascript:(function f() {" +
+                            "document.getElementById('p-donation').style.display='none'; " +
+                            "})()");
         }
 
         private String youtubeProtect(WebView view, String urlParameter) {
@@ -534,66 +490,6 @@ public class WebviewActivity extends AppCompatActivity {
 
 
     private class ChromeClient extends WebChromeClient {
-        protected FrameLayout mFullscreenContainer;
-        private View mCustomView;
-        private WebChromeClient.CustomViewCallback mCustomViewCallback;
-        private int mOriginalOrientation;
-        private int mOriginalSystemUiVisibility;
-
-        ChromeClient() {
-        }
-
-        // For Android 5.0
-        public boolean onShowFileChooser(WebView view, ValueCallback<Uri[]> filePath, WebChromeClient.FileChooserParams fileChooserParams) {
-            // Double check that we don't have any existing callbacks
-            if (mFilePathCallback != null) {
-                mFilePathCallback.onReceiveValue(null);
-            }
-            mFilePathCallback = filePath;
-
-            Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-            if (takePictureIntent.resolveActivity(getPackageManager()) != null) {
-                // Create the File where the photo should go
-                File photoFile = null;
-                try {
-                    photoFile = createImageFile();
-                    takePictureIntent.putExtra("PhotoPath", mCameraPhotoPath);
-                } catch (IOException ex) {
-                    // Error occurred while creating the File
-                    Log.e("ErrorCreatingFile", "Unable to create Image File", ex);
-                }
-
-                // Continue only if the File was successfully created
-                if (photoFile != null) {
-                    mCameraPhotoPath = "file:" + photoFile.getAbsolutePath();
-                    takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT,
-                            Uri.fromFile(photoFile));
-                } else {
-                    takePictureIntent = null;
-                }
-            }
-
-            Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
-            contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
-            contentSelectionIntent.setType("*/*");
-
-            Intent[] intentArray;
-            if (takePictureIntent != null) {
-                intentArray = new Intent[]{takePictureIntent};
-            } else {
-                intentArray = new Intent[0];
-            }
-
-            Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
-            chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
-            chooserIntent.putExtra(Intent.EXTRA_TITLE, "Upload De Arquivo");
-            chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
-
-            startActivityForResult(chooserIntent, INPUT_FILE_REQUEST_CODE);
-
-            return true;
-
-        }
 
         // openFileChooser for Android 3.0+
         public void openFileChooser(ValueCallback<Uri> uploadMsg, String acceptType) {
@@ -635,7 +531,7 @@ public class WebviewActivity extends AppCompatActivity {
 
             // Set camera intent to file chooser
             chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS
-                    , new Parcelable[] { captureIntent });
+                    , new Parcelable[]{captureIntent});
 
             // On select image call onActivityResult method of activity
             startActivityForResult(chooserIntent, FILECHOOSER_RESULTCODE);
@@ -669,46 +565,6 @@ public class WebviewActivity extends AppCompatActivity {
             dialog.show();
             result.confirm();
             return true;
-        }
-
-        public Bitmap getDefaultVideoPoster() {
-            if (mCustomView == null)
-                return null;
-
-            return BitmapFactory.decodeResource(getApplicationContext().getResources(), 2130837573);
-        }
-
-        public void onHideCustomView() {
-            ((FrameLayout) getWindow().getDecorView()).removeView(this.mCustomView);
-
-            this.mCustomView = null;
-
-            getWindow().getDecorView().setSystemUiVisibility(this.mOriginalSystemUiVisibility);
-            setRequestedOrientation(this.mOriginalOrientation);
-
-            this.mCustomViewCallback.onCustomViewHidden();
-            this.mCustomViewCallback = null;
-        }
-
-        public void onShowCustomView(View paramView,
-                                     WebChromeClient.CustomViewCallback paramCustomViewCallback) {
-            if (this.mCustomView != null) {
-                onHideCustomView();
-
-                return;
-            }
-
-            this.mCustomView = paramView;
-            this.mOriginalSystemUiVisibility = getWindow().getDecorView().getSystemUiVisibility();
-            this.mOriginalOrientation = getRequestedOrientation();
-            this.mCustomViewCallback = paramCustomViewCallback;
-
-            ((FrameLayout) getWindow().getDecorView()).addView(
-                    this.mCustomView,
-                    new FrameLayout.LayoutParams(-1, -1));
-
-            getWindow().getDecorView().setSystemUiVisibility(3846
-                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
         }
     }
 

--- a/app/src/main/java/org/cordova/quasar/corona/app/WikipediaActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WikipediaActivity.java
@@ -1,6 +1,5 @@
 package org.cordova.quasar.corona.app;
 
-import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -8,7 +7,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -25,26 +23,20 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
-import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import com.datami.smi.SdState;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -80,7 +72,7 @@ public class WikipediaActivity extends AppCompatActivity {
                             if (url.equals("https://classroom.google.com/a/estudante.se.df.gov.br")) {
                                 return true;
                             }
-                            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                            startActivity(new Intent(getApplicationContext(), ClassroomActivity.class)
                                     .putExtra("url",
                                             "https://classroom.google.com/a/estudante.se.df.gov.br"));
                             overridePendingTransition(0, 0);

--- a/app/src/main/res/layout/activity_classroom.xml
+++ b/app/src/main/res/layout/activity_classroom.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".WebviewActivity">
+    tools:context=".ClassroomActivity">
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"

--- a/app/src/main/res/layout/activity_wikipedia.xml
+++ b/app/src/main/res/layout/activity_wikipedia.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".WikipediaActivity">
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@+id/web_view"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="20dp"
+        android:layout_marginBottom="20dp"
+        android:background="#FFFFFF"
+        android:clickable="true"
+        android:focusable="true"
+        android:tint="#FFFFFF"
+        app:srcCompat="?attr/homeAsUpIndicator" />
+
+    <WebView
+        android:id="@+id/web_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/navigation" >
+
+    </WebView>
+
+    <ProgressBar
+        android:id="@+id/progressBar1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:indeterminateDrawable="@drawable/progress" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/navigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:background="@color/white"
+        android:paddingLeft="15dp"
+        android:paddingRight="15dp"
+        app:itemIconSize="20dp"
+        app:itemIconTint="@drawable/selector"
+        app:itemTextColor="@drawable/selector"
+        app:labelVisibilityMode="labeled"
+        app:menu="@menu/main_menu" >
+
+    </com.google.android.material.bottomnavigation.BottomNavigationView>
+
+</RelativeLayout>


### PR DESCRIPTION
Foi adicionada uma linha ao manifest para que fosse possível salvar temporariamente o conteúdo da webview. Como era utilizado um único webview para duas páginas (google class, wikipedia) foi necessário adicionar uma webview pra cada uma das telas. Dessa forma o conteúdo do webview não é perdido ao trocar de tela.


https://user-images.githubusercontent.com/45996980/113952760-b504d180-97ec-11eb-96de-23df2dac700f.mov

Resolve #61 