### PR TITLE
Tela com termos de política e privacidade

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-feature android:name="android.hardware.camera" />
 
+    <uses-feature android:name="android.hardware.camera" />
 
     <application
         android:name=".MyApplication"
@@ -22,15 +22,15 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
-
+        <activity android:name=".WelcomeActivity"></activity>
         <activity
             android:name=".WebviewActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".AboutActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".QuestionsActivity"
             android:configChanges="orientation|screenSize"

--- a/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
@@ -1,6 +1,8 @@
 package org.cordova.quasar.corona.app;
 
+import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -9,8 +11,34 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
-                .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
-        overridePendingTransition(0, 0);
+        FirstRun first_run = new FirstRun(getApplicationContext());
+        if(first_run.isFirstTime()){
+            startActivity(new Intent(getApplicationContext(), WelcomeActivity.class));
+            overridePendingTransition(0, 0);
+        }else{
+            startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                    .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
+            overridePendingTransition(0, 0);
+        }
     }
+
+}
+class FirstRun
+{
+    SharedPreferences sharedPreferences;
+    public FirstRun(Context context)
+    {
+        sharedPreferences = context.getSharedPreferences("myAppData", 0);
+    }
+
+    public boolean isFirstTime()
+    {
+        return sharedPreferences.getBoolean("first", true);
+    }
+
+    public void setFirstTime(boolean b)
+    {
+        sharedPreferences.edit().putBoolean("first", b).commit();
+    }
+
 }

--- a/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
@@ -8,12 +8,17 @@ import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class MainActivity extends AppCompatActivity {
+    private static FirstRun first_run;
+
+    public static FirstRun getFirstRun() {
+        return first_run;
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        FirstRun first_run = new FirstRun(getApplicationContext());
+        first_run = new FirstRun(getApplicationContext());
         if(first_run.isFirstTime()){
-            first_run.setFirstTime(false);
             startActivity(new Intent(getApplicationContext(), WelcomeActivity.class));
             overridePendingTransition(0, 0);
         }else{
@@ -22,7 +27,6 @@ public class MainActivity extends AppCompatActivity {
             overridePendingTransition(0, 0);
         }
     }
-
 }
 class FirstRun
 {

--- a/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/MainActivity.java
@@ -13,6 +13,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         FirstRun first_run = new FirstRun(getApplicationContext());
         if(first_run.isFirstTime()){
+            first_run.setFirstTime(false);
             startActivity(new Intent(getApplicationContext(), WelcomeActivity.class));
             overridePendingTransition(0, 0);
         }else{

--- a/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
@@ -3,6 +3,7 @@ package org.cordova.quasar.corona.app;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.annotation.SuppressLint;
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
@@ -24,6 +25,14 @@ public class WelcomeActivity extends AppCompatActivity {
 
         button = (Button) findViewById(R.id.button);
         checkbox = (CheckBox) findViewById(R.id.checkBox);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
+                        .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
+                overridePendingTransition(0, 0);
+            }
+        });
 
     }
     @SuppressLint("ResourceAsColor")

--- a/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
@@ -1,0 +1,17 @@
+package org.cordova.quasar.corona.app;
+
+import androidx.appcompat.app.AppCompatActivity;
+import android.os.Bundle;
+import android.webkit.WebView;
+
+public class WelcomeActivity extends AppCompatActivity {
+    WebView webView;
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_welcome);
+        String url = "https://escolaemcasa.se.df.gov.br/index.php/politica-de-privacidade/";
+        webView = (WebView) findViewById(R.id.web_view);
+        webView.loadUrl(url);
+    }
+}

--- a/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
@@ -31,19 +31,19 @@ public class WelcomeActivity extends AppCompatActivity {
                 startActivity(new Intent(getApplicationContext(), WebviewActivity.class)
                         .putExtra("url", "https://classroom.google.com/a/estudante.se.df.gov.br"));
                 overridePendingTransition(0, 0);
+                MainActivity.getFirstRun().setFirstTime(false);
             }
         });
-
     }
     @SuppressLint("ResourceAsColor")
     public void itemClicked(View v) {
         CheckBox checkBox = (CheckBox)v;
         if(checkBox.isChecked()){
             button.setEnabled(true);
-            button.setBackgroundColor(Color.rgb(32,146,229));
+            button.setBackgroundResource(R.drawable.button_enabled);
         }else{
             button.setEnabled(false);
-            button.setBackgroundColor(Color.GRAY);
+            button.setBackgroundResource(R.drawable.button_disabled);
         }
     }
 }

--- a/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
+++ b/app/src/main/java/org/cordova/quasar/corona/app/WelcomeActivity.java
@@ -1,11 +1,19 @@
 package org.cordova.quasar.corona.app;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.annotation.SuppressLint;
+import android.graphics.Color;
 import android.os.Bundle;
+import android.view.View;
 import android.webkit.WebView;
+import android.widget.Button;
+import android.widget.CheckBox;
 
 public class WelcomeActivity extends AppCompatActivity {
     WebView webView;
+    Button button;
+    CheckBox checkbox;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -13,5 +21,20 @@ public class WelcomeActivity extends AppCompatActivity {
         String url = "https://escolaemcasa.se.df.gov.br/index.php/politica-de-privacidade/";
         webView = (WebView) findViewById(R.id.web_view);
         webView.loadUrl(url);
+
+        button = (Button) findViewById(R.id.button);
+        checkbox = (CheckBox) findViewById(R.id.checkBox);
+
+    }
+    @SuppressLint("ResourceAsColor")
+    public void itemClicked(View v) {
+        CheckBox checkBox = (CheckBox)v;
+        if(checkBox.isChecked()){
+            button.setEnabled(true);
+            button.setBackgroundColor(Color.rgb(32,146,229));
+        }else{
+            button.setEnabled(false);
+            button.setBackgroundColor(Color.GRAY);
+        }
     }
 }

--- a/app/src/main/res/drawable/button_disabled.xml
+++ b/app/src/main/res/drawable/button_disabled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" android:padding="10dp">
+    <solid android:color="@android:color/darker_gray"/>
+    <corners android:radius="5dp"/>
+</shape>

--- a/app/src/main/res/drawable/button_enabled.xml
+++ b/app/src/main/res/drawable/button_enabled.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" android:padding="10dp">
+    <solid android:color="@color/ic_launcher_background"/>
+    <corners android:radius="5dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -22,7 +22,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="40dp"
         android:layout_marginEnd="30dp"
-        android:background="@android:color/darker_gray"
+        android:background="@drawable/button_disabled"
         android:enabled="false"
         android:text="Continuar"
         android:textColor="@color/realWhite"

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".WelcomeActivity">
+
+    <WebView
+        android:id="@+id/web_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginBottom="100dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        android:layout_marginEnd="30dp"
+        android:background="@color/ic_launcher_background"
+        android:text="Continuar"
+        android:textColor="@color/realWhite"
+        app:cornerRadius="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/web_view" />
+
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:text="Aceito os termos de política e privacidade."
+        android:textSize="18sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/web_view" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -22,7 +22,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="40dp"
         android:layout_marginEnd="30dp"
-        android:background="@color/ic_launcher_background"
+        android:background="@android:color/darker_gray"
+        android:enabled="false"
         android:text="Continuar"
         android:textColor="@color/realWhite"
         app:cornerRadius="8dp"
@@ -38,6 +39,7 @@
         android:text="Aceito os termos de política e privacidade."
         android:textSize="18sp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/web_view" />
+        app:layout_constraintTop_toBottomOf="@+id/web_view"
+        android:onClick="itemClicked"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 06 16:16:41 BRT 2020
+#Tue Apr 06 20:24:55 BRT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
Foi criada uma tela ao abrir o app pela primeira vez solicitando que o usuário aceite os termos. É mostrado os termos presentes aqui: https://escolaemcasa.se.df.gov.br/index.php/politica-de-privacidade/ através de um webview.
![Captura de Tela 2021-04-07 às 18 35 33](https://user-images.githubusercontent.com/45996980/113953373-0c577180-97ee-11eb-8b66-1b997fc18449.png)
![Captura de Tela 2021-04-07 às 18 39 04](https://user-images.githubusercontent.com/45996980/113953376-0e213500-97ee-11eb-8a83-8b62d362bc6c.png)

Resolve #63 
